### PR TITLE
error in phonegap build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 phonegap-googlemaps-plugin
 ==========================
+
+Notes: this is a fork of @Nipher version and @Nipher is a fork of @wf9a5m75
+
+For rapid acesss you can add the following lines to your config.xml on "Phonegap Build"
+
+	<gap:plugin name="plugin.google.maps.menusito" version="1.2.5">
+		<param name="API_KEY_FOR_ANDROID" value="abc" />
+		<param name="API_KEY_FOR_IOS" value="123" />
+	</gap:plugin>
+	
+	This version work well with cli-5.1.1
+	
+	
+
 This plugin helps you leverage [Google Maps Android SDK v2](https://developers.google.com/maps/documentation/android/) and [Google Maps SDK for iOS](https://developers.google.com/maps/documentation/ios/) with your JavaScript.
 Both [PhoneGap](http://phonegap.com/) and [Apache Cordova](http://cordova.apache.org/) are supported.
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="plugin.google.maps" version="1.2.5" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="plugin.google.maps.menusito" version="1.2.5" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>phonegap-googlemaps-plugin</name>
     <js-module name="phonegap-googlemaps-plugin" src="www/googlemaps-cdv-plugin.js">
         <clobbers target="plugin.google.maps" />


### PR DESCRIPTION
In build.phonegap.com

when i use this lines in config.xml:

< gap:plugin name="plugin.google.maps.menusito" version="1.2.5" >
< param name="API_KEY_FOR_ANDROID" value="------" / >
</ gap:plugin >

give me this error in:

Error - The following plugin (or plugin version) is not on npm or not available for this platform: /home/ec2-user/gimlet/var/plugins/dfe3d26a-1c56-11e5-bd0a-22000ba705f9 --var API_KEY_FOR_ANDROID=": Installing "plugin.google.maps.menusito" for android Fetching plugin "plugin.http.request

and i am using 3.7.0 phonegap version
